### PR TITLE
[AXAGENT-1682] Add Proxy Lookup Function To Config

### DIFF
--- a/client.go
+++ b/client.go
@@ -873,6 +873,7 @@ func (c *Client) handleServerUnsub(channel string, _ *protocol.Unsubscribe) {
 func (c *Client) getReconnectDelay() time.Duration {
 	return c.reconnectStrategy.timeBeforeNextAttempt(c.reconnectAttempts)
 }
+type ProxyFunc = func(*http.Request) (*url.URL, error)
 
 func (c *Client) startReconnecting() error {
 	c.mu.Lock()
@@ -888,6 +889,7 @@ func (c *Client) startReconnecting() error {
 	c.mu.Unlock()
 
 	wsConfig := websocketConfig{
+		Proxy:			   c.config.Proxy,
 		NetDialContext:    c.config.NetDialContext,
 		TLSConfig:         c.config.TLSConfig,
 		HandshakeTimeout:  c.config.HandshakeTimeout,

--- a/client.go
+++ b/client.go
@@ -99,9 +99,7 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 	if config.Name == "" {
 		config.Name = "go"
 	}
-	if config.Proxy == nil {
-		config.Proxy = http.ProxyFromEnvironment
-	}
+
 	// We support setting multiple endpoints to try in round-robin fashion. But
 	// for now this feature is not documented and used for internal tests. In most
 	// cases there should be a single public server WS endpoint.

--- a/client.go
+++ b/client.go
@@ -99,6 +99,9 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 	if config.Name == "" {
 		config.Name = "go"
 	}
+	if config.Proxy == nil {
+		config.Proxy = http.ProxyFromEnvironment
+	}
 	// We support setting multiple endpoints to try in round-robin fashion. But
 	// for now this feature is not documented and used for internal tests. In most
 	// cases there should be a single public server WS endpoint.

--- a/client.go
+++ b/client.go
@@ -873,7 +873,6 @@ func (c *Client) handleServerUnsub(channel string, _ *protocol.Unsubscribe) {
 func (c *Client) getReconnectDelay() time.Duration {
 	return c.reconnectStrategy.timeBeforeNextAttempt(c.reconnectAttempts)
 }
-type ProxyFunc = func(*http.Request) (*url.URL, error)
 
 func (c *Client) startReconnecting() error {
 	c.mu.Lock()

--- a/client.go
+++ b/client.go
@@ -888,7 +888,7 @@ func (c *Client) startReconnecting() error {
 	c.mu.Unlock()
 
 	wsConfig := websocketConfig{
-		Proxy:			   c.config.Proxy,
+		Proxy:             c.config.Proxy,
 		NetDialContext:    c.config.NetDialContext,
 		TLSConfig:         c.config.TLSConfig,
 		HandshakeTimeout:  c.config.HandshakeTimeout,

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -30,6 +31,9 @@ type Config struct {
 	// Version allows setting client version. This is an application
 	// specific information. By default, no version set.
 	Version string
+	// Proxy specifies the function responsible for determining the proxy URL. If
+	// Proxy is nil, http.ProxyFromEnvironment is used.
+	Proxy func(*http.Request) (*url.URL, error)
 	// NetDialContext specifies the dial function for creating TCP connections. If
 	// NetDialContext is nil, net.DialContext is used.
 	NetDialContext func(ctx context.Context, network, addr string) (net.Conn, error)

--- a/config.go
+++ b/config.go
@@ -31,8 +31,7 @@ type Config struct {
 	// Version allows setting client version. This is an application
 	// specific information. By default, no version set.
 	Version string
-	// Proxy specifies the function responsible for determining the proxy URL. If
-	// Proxy is nil, http.ProxyFromEnvironment is used.
+	// Proxy specifies the function responsible for determining the proxy URL.
 	Proxy func(*http.Request) (*url.URL, error)
 	// NetDialContext specifies the dial function for creating TCP connections. If
 	// NetDialContext is nil, net.DialContext is used.

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -96,10 +96,6 @@ type websocketConfig struct {
 func newWebsocketTransport(url string, protocolType protocol.Type, config websocketConfig) (transport, error) {
 	wsHeaders := config.Header
 
-	if config.Proxy == nil {
-		config.Proxy = http.ProxyFromEnvironment
-	}
-
 	dialer := &websocket.Dialer{}
 	dialer.Proxy = config.Proxy
 	dialer.NetDialContext = config.NetDialContext

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -63,8 +63,7 @@ type websocketTransport struct {
 
 // websocketConfig configures Websocket transport.
 type websocketConfig struct {
-	// Proxy specifies the function responsible for determining the proxy URL. If
-	// Proxy is nil, http.ProxyFromEnvironment is used.
+	// Proxy specifies the function responsible for determining the proxy URL.
 	Proxy func(*http.Request) (*url.URL, error)
 
 	// NetDialContext specifies the dial function for creating TCP connections. If


### PR DESCRIPTION
Added a proxy lookup function to the centrifuge client to enable customizations of proxies vs relying on the default `http.ProxyFromEnvironment` functionality.