### PR TITLE
[AXAGENT-1829] Correct Module Name

### DIFF
--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -17,7 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/centrifugal/centrifuge-go"
+	"github.com/PatchSimple/centrifuge-go"
 	"go.uber.org/ratelimit"
 )
 

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -11,7 +11,7 @@ import (
 
 	_ "net/http/pprof"
 
-	"github.com/centrifugal/centrifuge-go"
+	"github.com/PatchSimple/centrifuge-go"
 	"github.com/golang-jwt/jwt"
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,11 +1,11 @@
-module github.com/centrifugal/centrifuge-go/examples
+module github.com/PatchSimple/centrifuge-go/examples
 
 go 1.16
 
-replace github.com/centrifugal/centrifuge-go => ../
+replace github.com/PatchSimple/centrifuge-go => ../
 
 require (
-	github.com/centrifugal/centrifuge-go v0.3.0
+	github.com/PatchSimple/centrifuge-go v0.3.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	go.uber.org/ratelimit v0.2.0
 )

--- a/examples/refresh/main.go
+++ b/examples/refresh/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/centrifugal/centrifuge-go"
+	"github.com/PatchSimple/centrifuge-go"
 	"github.com/golang-jwt/jwt"
 )
 

--- a/examples/rpc/main.go
+++ b/examples/rpc/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/centrifugal/centrifuge-go"
+	"github.com/PatchSimple/centrifuge-go"
 )
 
 func newClient() *centrifuge.Client {

--- a/examples/token_subscription/main.go
+++ b/examples/token_subscription/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/centrifugal/centrifuge-go"
+	"github.com/PatchSimple/centrifuge-go"
 	"github.com/golang-jwt/jwt"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/centrifugal/centrifuge-go
+module github.com/PatchSimple/centrifuge-go
 
 go 1.19
 


### PR DESCRIPTION
The module name of the forked repo must point to itself for use in downstream repos. 