### PR TITLE
Default the proxy to maintain backwards compatibility

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,10 @@ type Config struct {
 	// Version allows setting client version. This is an application
 	// specific information. By default, no version set.
 	Version string
-	// Proxy specifies the function responsible for determining the proxy URL.
+	// Proxy specifies a function to return a proxy for a given Request.
+	// If the function returns a non-nil error, the request is aborted with the
+	// provided error. If function returns a nil *URL, no proxy is used.
+	// If Proxy is nil then http.ProxyFromEnvironment will be used.
 	Proxy func(*http.Request) (*url.URL, error)
 	// NetDialContext specifies the dial function for creating TCP connections. If
 	// NetDialContext is nil, net.DialContext is used.

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -63,7 +63,10 @@ type websocketTransport struct {
 
 // websocketConfig configures Websocket transport.
 type websocketConfig struct {
-	// Proxy specifies the function responsible for determining the proxy URL.
+	// Proxy specifies a function to return a proxy for a given Request.
+	// If the function returns a non-nil error, the request is aborted with the
+	// provided error. If function returns a nil *URL, no proxy is used.
+	// If Proxy is nil then http.ProxyFromEnvironment will be used.
 	Proxy func(*http.Request) (*url.URL, error)
 
 	// NetDialContext specifies the dial function for creating TCP connections. If
@@ -96,7 +99,11 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 	wsHeaders := config.Header
 
 	dialer := &websocket.Dialer{}
-	dialer.Proxy = config.Proxy
+	if config.Proxy != nil {
+		dialer.Proxy = config.Proxy
+	} else {
+		dialer.Proxy = http.ProxyFromEnvironment
+	}
 	dialer.NetDialContext = config.NetDialContext
 
 	dialer.HandshakeTimeout = config.HandshakeTimeout


### PR DESCRIPTION
Update the default value for `Proxy` configs so that they default to `http.ProxyFromEnvironment` instead of no proxy.