### PR TITLE
Replace mutex's with channel based mutex.

### DIFF
--- a/client.go
+++ b/client.go
@@ -163,7 +163,7 @@ func (c *Client) Connect() error {
 // Disconnect client from server. It's still possible to connect again later. If
 // you don't need Client anymore – use Client.Close.
 func (c *Client) Disconnect(ctx context.Context) error {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func (c *Client) Disconnect(ctx context.Context) error {
 // Close closes Client and cleanups resources. Client is unusable after this. Use this
 // method if you don't need client anymore, otherwise look at Client.Disconnect.
 func (c *Client) Close(ctx context.Context) error {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func (c *Client) Subscriptions() map[string]*Subscription {
 // Send message to server without waiting for response.
 // Message handler must be registered on server.
 func (c *Client) Send(ctx context.Context, data []byte) error {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ type RPCResult struct {
 // RPC allows sending data to a server and waiting for a response.
 // RPC handler must be registered on server.
 func (c *Client) RPC(ctx context.Context, method string, data []byte) (RPCResult, error) {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return RPCResult{}, err
 	}
@@ -329,7 +329,10 @@ func (c *Client) nextCmdID() uint32 {
 	return atomic.AddUint32(&c.cmdID, 1)
 }
 
-func (c *Client) stateEqCtx(ctx context.Context, state State) (bool, error) {
+// stateEq checks if the given state is equal to the current state of the
+// client. it return an error if it fails to obtain the lock before the context
+// is done.
+func (c *Client) stateEq(ctx context.Context, state State) (bool, error) {
 	if err := c.mu.TryLockCtx(ctx); err != nil { // was c.mu.RLock()
 		return false, fmt.Errorf("failed to obtain lock for getState: %w", err)
 	}
@@ -1502,7 +1505,7 @@ type PublishResult struct{}
 
 // Publish data into channel.
 func (c *Client) Publish(ctx context.Context, channel string, data []byte) (PublishResult, error) {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return PublishResult{}, err
 	}
@@ -1576,7 +1579,7 @@ type HistoryResult struct {
 
 // History for a channel without being subscribed.
 func (c *Client) History(ctx context.Context, channel string, opts ...HistoryOption) (HistoryResult, error) {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return HistoryResult{}, err
 	}
@@ -1674,7 +1677,7 @@ type PresenceResult struct {
 
 // Presence for a channel without being subscribed.
 func (c *Client) Presence(ctx context.Context, channel string) (PresenceResult, error) {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return PresenceResult{}, err
 	}
@@ -1758,7 +1761,7 @@ type PresenceStatsResult struct {
 
 // PresenceStats for a channel without being subscribed.
 func (c *Client) PresenceStats(ctx context.Context, channel string) (PresenceStatsResult, error) {
-	isClosed, err := c.stateEqCtx(ctx, StateClosed)
+	isClosed, err := c.stateEq(ctx, StateClosed)
 	if err != nil {
 		return PresenceStatsResult{}, err
 	}

--- a/client.go
+++ b/client.go
@@ -331,7 +331,7 @@ func (c *Client) nextCmdID() uint32 {
 }
 
 func (c *Client) getStateCtx(ctx context.Context) (State, error) {
-	if err := c.mu.LockCtx(ctx); err != nil {
+	if err := c.mu.TryLockCtx(ctx); err != nil {
 		return "", fmt.Errorf("failed to obtain lock for getState: %w", err)
 	}
 	defer c.mu.Unlock()
@@ -1468,7 +1468,7 @@ func (c *Client) resolveConnectFutures(err error) {
 }
 
 func (c *Client) onConnect(ctx context.Context, fn func(err error)) error {
-	if err := c.mu.LockCtx(ctx); err != nil {
+	if err := c.mu.TryLockCtx(ctx); err != nil {
 		return fmt.Errorf("failed to obtain lock for onConnect: %w", err)
 	}
 	defer c.mu.Unlock()

--- a/client.go
+++ b/client.go
@@ -192,7 +192,7 @@ func (c *Client) Close(ctx context.Context) error {
 // State returns current Client state. Note that while you are processing
 // this state - Client can move to a new one.
 func (c *Client) State() State {
-	c.mu.Lock()
+	c.mu.Lock() // was c.mu.RLock()
 	defer c.mu.Unlock()
 	return c.state
 }
@@ -529,7 +529,7 @@ func (c *Client) moveToConnecting(code uint32, reason string) {
 }
 
 func (c *Client) moveToClosed() {
-	c.mu.Lock() // was c.mu.RLock()
+	c.mu.Lock()
 	slog.Debug(
 		"centrifuge client is attempting to move to a closed state",
 		"currentState", c.state,
@@ -724,7 +724,7 @@ func (c *Client) handle(reply *protocol.Reply) {
 			}
 			return
 		}
-		c.mu.Lock() // was c.mu.RLock()
+		c.mu.Lock()
 		if c.state != StateConnected {
 			c.mu.Unlock()
 			return

--- a/client.go
+++ b/client.go
@@ -35,20 +35,18 @@ const (
 // Close method to clean up state when you don't need client instance
 // anymore.
 type Client struct {
-	futureID       uint64
-	cmdID          uint32
-	mu             mutex.Mutex
-	endpoints      []string
-	round          int
-	protocolType   protocol.Type
-	config         Config
-	token          string
-	data           protocol.Raw
-	transport      transport
-	disconnectedCh chan struct{}
-	state          State
-	// stateTimeout is the maximum time to wait for state lock, zero is unlimited.
-	stateTimeout      time.Duration
+	futureID          uint64
+	cmdID             uint32
+	mu                mutex.Mutex
+	endpoints         []string
+	round             int
+	protocolType      protocol.Type
+	config            Config
+	token             string
+	data              protocol.Raw
+	transport         transport
+	disconnectedCh    chan struct{}
+	state             State
 	subs              map[string]*Subscription
 	serverSubs        map[string]*serverSub
 	requestsMu        mutex.Mutex
@@ -141,7 +139,6 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 		token:             config.Token,
 		data:              config.Data,
 		closeCh:           make(chan struct{}),
-		stateTimeout:      time.Minute, // safe to say, if we have to wait for more than a minute, something is wrong.
 	}
 
 	// Queue to run callbacks on.

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/centrifugal/centrifuge-go/internal/mutex"
 )
 
 type testEventHandler struct {
@@ -554,7 +556,7 @@ func TestConcurrentPublishSubscribeDisconnect(t *testing.T) {
 
 func TestClient_onConnect_respects_context_cancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	client := &Client{}
+	client := &Client{mu: mutex.New()}
 	client.mu.Lock()
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -573,7 +575,7 @@ func TestClient_onConnect_respects_context_cancel(t *testing.T) {
 
 func TestClient_publish_respects_context_cancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	client := &Client{}
+	client := &Client{mu: mutex.New()}
 	client.mu.Lock()
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/internal/fsm/state_machine.go
+++ b/internal/fsm/state_machine.go
@@ -1,0 +1,53 @@
+package fsm
+
+import "github.com/centrifugal/centrifuge-go/internal/mutex"
+
+type State int
+
+const (
+	StateDisconnected State = iota
+	StateConnecting
+	StateConnected
+	StateClosed
+)
+
+type StateMachine struct {
+	// state is the current state of the state machine.
+	state State
+	// stateMu is used to protect the state of the state machine.
+	stateMu mutex.Mutex
+}
+
+func NewStateMachine() *StateMachine {
+	return &StateMachine{
+		state: StateDisconnected,
+	}
+}
+
+func (sm *StateMachine) State() State {
+	sm.stateMu.Lock()
+	defer sm.stateMu.Unlock()
+	return sm.state
+}
+
+func (sm *StateMachine) SetState(state State) {
+	sm.stateMu.Lock()
+	defer sm.stateMu.Unlock()
+	sm.state = state
+}
+
+func (sm *StateMachine) IsDisconnected() bool {
+	return sm.State() == StateDisconnected
+}
+
+func (sm *StateMachine) IsConnecting() bool {
+	return sm.State() == StateConnecting
+}
+
+func (sm *StateMachine) IsConnected() bool {
+	return sm.State() == StateConnected
+}
+
+func (sm *StateMachine) IsClosed() bool {
+	return sm.State() == StateClosed
+}

--- a/internal/mutex/mutex.go
+++ b/internal/mutex/mutex.go
@@ -1,0 +1,85 @@
+package mutex
+
+import (
+	"context"
+	"sync"
+)
+
+// Mutex is a drop-in replacement for the standard libraries sync.Mutex. It
+// offers the ability cancel waiting to obtain a lock by making use of Go's
+// select statement.
+//
+// The zero value is safe to use.
+type Mutex struct {
+	initMu sync.Mutex
+
+	// state must be a buffered mmutex of 1.
+	// locked: len(state) == 1
+	// unlocked: len(state) == 0
+	state chan struct{}
+}
+
+// init is used to fix a zero value Mutex.
+func (m *Mutex) init() {
+	m.initMu.Lock()
+	defer m.initMu.Unlock()
+	if m.state == nil {
+		m.state = make(chan struct{}, 1)
+	}
+}
+
+func (m *Mutex) waitLock() chan<- struct{} {
+	m.init()
+	return m.state
+}
+
+// WaitLock give access to internal state of the mutex and a send chan. do not
+// close the chan, it will be cleaned up by gc. closing the channel will break
+// the Mutex. Only use the chan it to send en empty struct to obtain the lock.
+func (m *Mutex) WaitLock() chan<- struct{} {
+	return m.waitLock()
+}
+
+// LockCtx is a convience func for selecting WaitLock and ctx. If the ctx is
+// done the ctx error will be returned.
+func (m *Mutex) LockCtx(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case m.waitLock() <- struct{}{}:
+		return nil
+	}
+}
+
+// Lock locks m. If the lock is already in use, the calling goroutine blocks
+// until the mutex is available.
+func (m *Mutex) Lock() {
+	m.waitLock() <- struct{}{}
+}
+
+// TryLock tries to lock m and reports whether it succeeded.
+//
+// Note that while correct uses of TryLock do exist, they are rare, and use of
+// TryLock is often a sign of a deeper problem in a particular use of mutexes.
+func (m *Mutex) TryLock() bool {
+	select {
+	case m.waitLock() <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Unlock unlocks m. It is a run-time error if m is not locked on entry to
+// Unlock.
+//
+// Calling unlock on an unlocked lock is generally an indication of a race
+// condition.
+func (m *Mutex) Unlock() {
+	m.init()
+	select {
+	case <-m.state:
+	default:
+		panic("unlock of unlocked mutex")
+	}
+}

--- a/internal/mutex/mutex.go
+++ b/internal/mutex/mutex.go
@@ -40,9 +40,9 @@ func (m *Mutex) WaitLock() chan<- struct{} {
 	return m.waitLock()
 }
 
-// LockCtx is a convience func for selecting WaitLock and ctx. If the ctx is
+// TryLockCtx is a convenience method for selecting WaitLock and ctx. If the ctx is
 // done the ctx error will be returned.
-func (m *Mutex) LockCtx(ctx context.Context) error {
+func (m *Mutex) TryLockCtx(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/internal/mutex/mutex.go
+++ b/internal/mutex/mutex.go
@@ -4,9 +4,8 @@ import (
 	"context"
 )
 
-// Mutex is a drop-in replacement for the standard libraries sync.Mutex. It
-// offers the ability cancel waiting to obtain a lock by making use of Go's
-// select statement.
+// Mutex is like sync.Mutex. It offers the ability cancel waiting to obtain a
+// lock by making use of Go's select statement.
 //
 // The zero value is not safe to use, and will cause a deadlock. You must
 // initialize a Mutex before using the New() func.

--- a/internal/mutex/mutex_test.go
+++ b/internal/mutex/mutex_test.go
@@ -51,7 +51,7 @@ func TestMutexTryLock_already_locked(t *testing.T) {
 
 func TestMutexLockCtx(t *testing.T) {
 	var mu Mutex
-	if err := mu.LockCtx(t.Context()); err != nil {
+	if err := mu.TryLockCtx(t.Context()); err != nil {
 		t.Fatal("failed to obtain lock")
 	}
 	defer mu.Unlock()
@@ -66,7 +66,7 @@ func TestMutexLockCtx_cancels(t *testing.T) {
 	mu.state <- struct{}{}
 	ctx, cancel := context.WithCancel(t.Context())
 	go cancel()
-	if err := mu.LockCtx(ctx); !errors.Is(err, context.Canceled) {
+	if err := mu.TryLockCtx(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatal("did not receive context cancel error")
 	}
 }

--- a/internal/mutex/mutex_test.go
+++ b/internal/mutex/mutex_test.go
@@ -1,0 +1,113 @@
+package mutex
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestMutexWaitLock(t *testing.T) {
+	var mu Mutex
+	mu.WaitLock() <- struct{}{}
+	defer mu.Unlock()
+	if len(mu.state) != 1 {
+		t.Fatal("failed to set lock state")
+	}
+}
+
+func TestMutexLock(t *testing.T) {
+	var mu Mutex
+	mu.Lock()
+	defer mu.Unlock()
+	if len(mu.state) != 1 {
+		t.Fatal("failed to set lock state")
+	}
+}
+
+func TestMutexTryLock(t *testing.T) {
+	var mu Mutex
+	if !mu.TryLock() {
+		t.Fatal("failed to obtain lock")
+	}
+	defer mu.Unlock()
+	if len(mu.state) != 1 {
+		t.Fatal("failed to set lock state")
+	}
+}
+
+func TestMutexTryLock_already_locked(t *testing.T) {
+	var mu Mutex
+	mu.init()
+	mu.state <- struct{}{}
+	if mu.TryLock() {
+		t.Fatal("obtain lock")
+	}
+	defer mu.Unlock()
+	if len(mu.state) != 1 {
+		t.Fatal("failed to set lock state")
+	}
+}
+
+func TestMutexLockCtx(t *testing.T) {
+	var mu Mutex
+	if err := mu.LockCtx(t.Context()); err != nil {
+		t.Fatal("failed to obtain lock")
+	}
+	defer mu.Unlock()
+	if len(mu.state) != 1 {
+		t.Fatal("failed to set lock state")
+	}
+}
+
+func TestMutexLockCtx_cancels(t *testing.T) {
+	var mu Mutex
+	mu.init()
+	mu.state <- struct{}{}
+	ctx, cancel := context.WithCancel(t.Context())
+	go cancel()
+	if err := mu.LockCtx(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatal("did not receive context cancel error")
+	}
+}
+
+func TestMutexUnlock(t *testing.T) {
+	var mu Mutex
+	mu.init()
+	mu.state <- struct{}{}
+	mu.Unlock()
+	if len(mu.state) != 0 {
+		t.Fatal("failed to set unlock state")
+	}
+}
+
+func TestMutexUnlock_panics_when_unlocked(t *testing.T) {
+	var mu Mutex
+	defer func() {
+		if v := recover(); v == nil {
+			t.Fatal("failed to panic when unlocking an unlocked mutex")
+		}
+		if len(mu.state) != 0 {
+			t.Fatal("mutated state of unlocked mutex")
+		}
+	}()
+	mu.Unlock()
+}
+
+// if Mutex does not work this is a race condition.
+// must be tested with "-race"
+func TestMutexLock_race(t *testing.T) {
+	var mu Mutex
+	var x int
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mu.Lock()
+			defer mu.Unlock()
+			x++
+		}()
+	}
+	wg.Wait()
+}

--- a/subscription.go
+++ b/subscription.go
@@ -340,7 +340,7 @@ func (s *Subscription) presenceStats(ctx context.Context, fn func(PresenceStatsR
 
 // Unsubscribe allows unsubscribing from channel.
 func (s *Subscription) Unsubscribe(ctx context.Context) error {
-	isClosed, err := s.centrifuge.stateEqCtx(ctx, StateClosed)
+	isClosed, err := s.centrifuge.stateEq(ctx, StateClosed)
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func (s *Subscription) unsubscribe(code uint32, reason string, sendUnsubscribe b
 
 // Subscribe allows initiating subscription process.
 func (s *Subscription) Subscribe(ctx context.Context) error {
-	isClosed, err := s.centrifuge.stateEqCtx(ctx, StateClosed)
+	isClosed, err := s.centrifuge.stateEq(ctx, StateClosed)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func (s *Subscription) Subscribe(ctx context.Context) error {
 		})
 	}
 
-	isConnected, err := s.centrifuge.stateEqCtx(ctx, StateConnected)
+	isConnected, err := s.centrifuge.stateEq(ctx, StateConnected)
 	if err != nil {
 		return err
 	}

--- a/subscription.go
+++ b/subscription.go
@@ -46,6 +46,7 @@ func newSubscription(c *Client, channel string, config ...SubscriptionConfig) *S
 		events:              newSubscriptionEventHub(),
 		subFutures:          make(map[uint64]subFuture),
 		resubscribeStrategy: defaultBackoffReconnect,
+		mu:                  mutex.New(),
 	}
 	if len(config) == 1 {
 		cfg := config[0]
@@ -64,7 +65,7 @@ func newSubscription(c *Client, channel string, config ...SubscriptionConfig) *S
 type Subscription struct {
 	futureID uint64 // Keep atomic on top!
 
-	mu         mutex.Mutex
+	mu         *mutex.Mutex
 	centrifuge *Client
 
 	// Channel for a subscription.

--- a/subscription.go
+++ b/subscription.go
@@ -339,11 +339,11 @@ func (s *Subscription) presenceStats(ctx context.Context, fn func(PresenceStatsR
 
 // Unsubscribe allows unsubscribing from channel.
 func (s *Subscription) Unsubscribe(ctx context.Context) error {
-	state, err := s.centrifuge.getStateCtx(ctx)
+	isClosed, err := s.centrifuge.stateEqCtx(ctx, StateClosed)
 	if err != nil {
 		return err
 	}
-	if state == StateClosed {
+	if isClosed {
 		return ErrClientClosed
 	}
 	s.unsubscribe(unsubscribedUnsubscribeCalled, "unsubscribe called", true)
@@ -364,11 +364,11 @@ func (s *Subscription) unsubscribe(code uint32, reason string, sendUnsubscribe b
 
 // Subscribe allows initiating subscription process.
 func (s *Subscription) Subscribe(ctx context.Context) error {
-	state, err := s.centrifuge.getStateCtx(ctx)
+	isClosed, err := s.centrifuge.stateEqCtx(ctx, StateClosed)
 	if err != nil {
 		return err
 	}
-	if state == StateClosed {
+	if isClosed {
 		return ErrClientClosed
 	}
 	s.mu.Lock()
@@ -389,11 +389,11 @@ func (s *Subscription) Subscribe(ctx context.Context) error {
 		})
 	}
 
-	state, err = s.centrifuge.getStateCtx(ctx)
+	isConnected, err := s.centrifuge.stateEqCtx(ctx, StateConnected)
 	if err != nil {
 		return err
 	}
-	if state != StateConnected {
+	if !isConnected {
 		return ErrClientClosed
 	}
 	s.resubscribe()

--- a/subscription.go
+++ b/subscription.go
@@ -3,10 +3,10 @@ package centrifuge
 import (
 	"context"
 	"errors"
-	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/centrifugal/centrifuge-go/internal/mutex"
 	"github.com/centrifugal/protocol"
 )
 
@@ -64,7 +64,7 @@ func newSubscription(c *Client, channel string, config ...SubscriptionConfig) *S
 type Subscription struct {
 	futureID uint64 // Keep atomic on top!
 
-	mu         sync.RWMutex
+	mu         mutex.Mutex
 	centrifuge *Client
 
 	// Channel for a subscription.
@@ -94,8 +94,8 @@ type Subscription struct {
 }
 
 func (s *Subscription) State() SubState {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.state
 }
 
@@ -338,8 +338,12 @@ func (s *Subscription) presenceStats(ctx context.Context, fn func(PresenceStatsR
 }
 
 // Unsubscribe allows unsubscribing from channel.
-func (s *Subscription) Unsubscribe() error {
-	if s.centrifuge.isClosed() {
+func (s *Subscription) Unsubscribe(ctx context.Context) error {
+	state, err := s.centrifuge.getStateCtx(ctx)
+	if err != nil {
+		return err
+	}
+	if state == StateClosed {
 		return ErrClientClosed
 	}
 	s.unsubscribe(unsubscribedUnsubscribeCalled, "unsubscribe called", true)
@@ -359,8 +363,12 @@ func (s *Subscription) unsubscribe(code uint32, reason string, sendUnsubscribe b
 }
 
 // Subscribe allows initiating subscription process.
-func (s *Subscription) Subscribe() error {
-	if s.centrifuge.isClosed() {
+func (s *Subscription) Subscribe(ctx context.Context) error {
+	state, err := s.centrifuge.getStateCtx(ctx)
+	if err != nil {
+		return err
+	}
+	if state == StateClosed {
 		return ErrClientClosed
 	}
 	s.mu.Lock()
@@ -381,8 +389,12 @@ func (s *Subscription) Subscribe() error {
 		})
 	}
 
-	if !s.centrifuge.isConnected() {
-		return nil
+	state, err = s.centrifuge.getStateCtx(ctx)
+	if err != nil {
+		return err
+	}
+	if state != StateConnected {
+		return ErrClientClosed
 	}
 	s.resubscribe()
 	return nil

--- a/subscription.go
+++ b/subscription.go
@@ -95,7 +95,7 @@ type Subscription struct {
 }
 
 func (s *Subscription) State() SubState {
-	s.mu.Lock()
+	s.mu.Lock() // was s.mu.RLock()
 	defer s.mu.Unlock()
 	return s.state
 }

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -50,7 +50,7 @@ func extractDisconnectWebsocket(err error) *disconnect {
 }
 
 type websocketTransport struct {
-	mu             mutex.Mutex
+	mu             *mutex.Mutex
 	conn           *websocket.Conn
 	protocolType   protocol.Type
 	commandEncoder protocol.CommandEncoder
@@ -130,6 +130,7 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 		closeCh:        make(chan struct{}),
 		commandEncoder: newCommandEncoder(protocolType),
 		protocolType:   protocolType,
+		mu:             mutex.New(),
 	}
 	go t.reader()
 	return t, nil

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -9,9 +9,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
+	"github.com/centrifugal/centrifuge-go/internal/mutex"
 	"github.com/centrifugal/protocol"
 	"github.com/gorilla/websocket"
 )
@@ -50,7 +50,7 @@ func extractDisconnectWebsocket(err error) *disconnect {
 }
 
 type websocketTransport struct {
-	mu             sync.Mutex
+	mu             *mutex.Mutex
 	conn           *websocket.Conn
 	protocolType   protocol.Type
 	commandEncoder protocol.CommandEncoder

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -50,7 +50,7 @@ func extractDisconnectWebsocket(err error) *disconnect {
 }
 
 type websocketTransport struct {
-	mu             *mutex.Mutex
+	mu             mutex.Mutex
 	conn           *websocket.Conn
 	protocolType   protocol.Type
 	commandEncoder protocol.CommandEncoder


### PR DESCRIPTION
This adds chan based mutex, which play nicely with contexts. this will makes state checking cancelable.

This pr is motivated by the fact that we keep getting customers that get stuck in a "reconnecting" state. when this happens everything that depends on state checking seems to fail. This initial change will allow us to check the state of the client without getting deadlocked ourselves.

This PR changes a few exported methods. so these are breaking changes. the following rules were followed that determined if an exported method needed to change: 
- Any function that takes a context, should return an error. This will inform the caller that the function did not have time to finish its work and exited early. (pretty standard pattern)
- Any function that interacts with state should take a context, so that it can cancel waiting on that state. 

following these rules we can see changes such as:

original:

```
func (c *Client) Close()
```

change:

```
func (c *Client) Close(ctx context.Context) error 
```