### PR TITLE
State method takes a context

### DIFF
--- a/client.go
+++ b/client.go
@@ -191,10 +191,12 @@ func (c *Client) Close(ctx context.Context) error {
 
 // State returns current Client state. Note that while you are processing
 // this state - Client can move to a new one.
-func (c *Client) State() State {
-	c.mu.Lock() // was c.mu.RLock()
+func (c *Client) State(ctx context.Context) (State, error) {
+	if err := c.mu.TryLockCtx(ctx); err != nil { // was c.mu.RLock()
+		return "", fmt.Errorf("failed to obtain lock for getState: %w", err)
+	}
 	defer c.mu.Unlock()
-	return c.state
+	return c.state, nil
 }
 
 // SetToken allows updating Client's connection token.

--- a/client_test.go
+++ b/client_test.go
@@ -631,3 +631,38 @@ func TestClient_stateEq(t *testing.T) {
 		t.Fatalf("expected state to be disconnected")
 	}
 }
+
+func TestClient_State(t *testing.T) {
+	client := &Client{
+		mu: mutex.New(),
+	}
+	client.state = StateDisconnected
+	state, err := client.State(newCtx(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != StateDisconnected {
+		t.Fatalf("expected state to be disconnected")
+	}
+}
+
+func TestClient_State_respects_context(t *testing.T) {
+	client := &Client{
+		mu: mutex.New(),
+	}
+	client.mu.Lock() // simulate deadlock
+	defer client.mu.Unlock()
+	ctx, cancel := context.WithCancel(newCtx(t))
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cancel()
+	}()
+	_, err := client.State(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled error, got %v", err)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Missed this in previous prs, too much code to change...

Changes `State() State` to `State(ctx context.Context) (State, error)`. This will allow us to check state without deadlocking if the client is stuck.