### PR TITLE
kamikaze mutex

### DIFF
--- a/internal/mutex/mutex.go
+++ b/internal/mutex/mutex.go
@@ -8,9 +8,9 @@ import (
 )
 
 // KamikazeMutex is a drop-in replacement for sync.Mutex. It calls os.Exit if a
-// lock can not be acquired within the specified timeout.
+// lock cannot be acquired within the specified timeout.
 type KamikazeMutex struct {
-	x       chan struct{} // if len(x) == 1 then locked
+	x       chan struct{} // If len(x) == 1, then the mutex is locked.
 	timeout time.Duration
 }
 
@@ -21,8 +21,8 @@ func NewKamikazeMutex(timeout time.Duration) *KamikazeMutex {
 	}
 }
 
-// lock will block until the lock can be acquired or the timeout is reached. If
-// the timeout is reached, it panics.
+// Lock will block until the lock can be acquired or the timeout is reached. If
+// the timeout is reached, it calls os.Exit.
 func (m *KamikazeMutex) Lock() {
 	select {
 	case <-time.After(m.timeout):
@@ -33,7 +33,7 @@ func (m *KamikazeMutex) Lock() {
 		)
 		os.Exit(1)
 	case m.x <- struct{}{}:
-		// lock acquired
+		// Lock acquired.
 	}
 }
 
@@ -45,12 +45,15 @@ func (m *KamikazeMutex) Unlock() {
 	}
 }
 
-// RLock is just a placeholder for compatibility. its really just a normal lock.
+// RLock is a placeholder for compatibility. It is functionally equivalent to a
+// normal lock.
 func (m *KamikazeMutex) RLock() bool {
 	m.Lock()
 	return true
 }
 
+// RUnlock is a placeholder for compatibility. It is functionally equivalent to
+// a normal unlock.
 func (m *KamikazeMutex) RUnlock() {
 	m.Unlock()
 }

--- a/internal/mutex/mutex.go
+++ b/internal/mutex/mutex.go
@@ -1,0 +1,56 @@
+package mutex
+
+import (
+	"log/slog"
+	"os"
+	"runtime/debug"
+	"time"
+)
+
+// KamikazeMutex is a drop-in replacement for sync.Mutex. It calls os.Exit if a
+// lock can not be acquired within the specified timeout.
+type KamikazeMutex struct {
+	x       chan struct{} // if len(x) == 1 then locked
+	timeout time.Duration
+}
+
+func NewKamikazeMutex(timeout time.Duration) *KamikazeMutex {
+	return &KamikazeMutex{
+		x:       make(chan struct{}, 1),
+		timeout: timeout,
+	}
+}
+
+// lock will block until the lock can be acquired or the timeout is reached. If
+// the timeout is reached, it panics.
+func (m *KamikazeMutex) Lock() {
+	select {
+	case <-time.After(m.timeout):
+		stackTrace := debug.Stack()
+		slog.Error("deadlock detected",
+			"timeout", m.timeout.String(),
+			"stack_trace", stackTrace,
+		)
+		os.Exit(1)
+	case m.x <- struct{}{}:
+		// lock acquired
+	}
+}
+
+func (m *KamikazeMutex) Unlock() {
+	select {
+	case <-m.x:
+	default:
+		panic("mutex is not locked")
+	}
+}
+
+// RLock is just a placeholder for compatibility. its really just a normal lock.
+func (m *KamikazeMutex) RLock() bool {
+	m.Lock()
+	return true
+}
+
+func (m *KamikazeMutex) RUnlock() {
+	m.Unlock()
+}

--- a/internal/mutex/mutex_test.go
+++ b/internal/mutex/mutex_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 package mutex
 
 import (

--- a/internal/mutex/mutex_test.go
+++ b/internal/mutex/mutex_test.go
@@ -1,0 +1,84 @@
+//go:build !race
+
+package mutex
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// Helper to create a KamikazeMutex with a short timeout.
+func newTestMutex() *KamikazeMutex {
+	return NewKamikazeMutex(time.Minute)
+}
+
+func TestKamikazeMutex_LockUnlock(t *testing.T) {
+	m := newTestMutex()
+	m.Lock()
+	m.Unlock() //nolint:staticcheck // Sis is intentional to test the mutex behavior
+}
+
+func TestKamikazeMutex_UnlockWithoutLockPanics(t *testing.T) {
+	m := newTestMutex()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on Unlock without Lock")
+		}
+	}()
+	m.Unlock()
+}
+
+func TestKamikazeMutex_LockTimeout_Exits(t *testing.T) {
+	// This test runs a subprocess to check for os.Exit(1).
+	code := `
+package main
+import (
+	"time"
+	"os"
+	"github.com/centrifugal/centrifuge-go/internal/mutex"
+)
+func main() {
+	m := mutex.NewKamikazeMutex(50 * time.Millisecond)
+	m.Lock()
+	go func() {
+		// Hold the lock for longer than the timeout.
+		time.Sleep(200 * time.Millisecond)
+		m.Unlock()
+	}()
+	m.Lock() // should timeout and call os.Exit(1)
+	os.Exit(0) // should not reach here
+}
+`
+	tmp := t.TempDir() + "/main.go"
+	if err := os.WriteFile(tmp, []byte(code), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "run", tmp)
+	err := cmd.Run()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitErr.ExitCode())
+		}
+	} else {
+		t.Fatalf("expected process to exit with error, got %v", err)
+	}
+}
+
+func TestKamikazeMutex_RLockRUnlock(t *testing.T) {
+	m := newTestMutex()
+	ok := m.RLock()
+	if !ok {
+		t.Fatal("RLock should return true")
+	}
+	m.RUnlock()
+}
+
+func TestKamikazeMutex_LockAfterUnlock(t *testing.T) {
+	m := newTestMutex()
+	m.Lock()
+	m.Unlock() //nolint:staticcheck // Sis is intentional to test the mutex behavior
+	m.Lock()
+	m.Unlock() //nolint:staticcheck // Sis is intentional to test the mutex behavior
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/centrifugal/centrifuge-go/internal/mutex"
 )
 
 func assertTrue(t *testing.T, condition bool, msg string) {
@@ -21,8 +23,9 @@ func assertEqual(t *testing.T, expected, actual interface{}, msg string) {
 func newTestQueue() *cbQueue {
 	q := &cbQueue{
 		closeCh: make(chan struct{}),
+		mu:      mutex.NewKamikazeMutex(defaultDeadlockTimeout),
 	}
-	q.cond = sync.NewCond(&q.mu)
+	q.cond = sync.NewCond(q.mu)
 	return q
 }
 

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -9,9 +9,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
+	"github.com/centrifugal/centrifuge-go/internal/mutex"
 	"github.com/centrifugal/protocol"
 	"github.com/gorilla/websocket"
 )
@@ -50,7 +50,7 @@ func extractDisconnectWebsocket(err error) *disconnect {
 }
 
 type websocketTransport struct {
-	mu             sync.Mutex
+	mu             *mutex.KamikazeMutex
 	conn           *websocket.Conn
 	protocolType   protocol.Type
 	commandEncoder protocol.CommandEncoder
@@ -130,6 +130,7 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 		closeCh:        make(chan struct{}),
 		commandEncoder: newCommandEncoder(protocolType),
 		protocolType:   protocolType,
+		mu:             mutex.NewKamikazeMutex(defaultDeadlockTimeout),
 	}
 	go t.reader()
 	return t, nil


### PR DESCRIPTION
Adds a mutex that os.Exits when a deadlock is detected. This is extreme behavior that will likely get reverted in favor of a more graceful solution when the deadlock is found and fixed. In the mean time the os.Exit will help to prevent an code from being stuck. we can handle restarting the program by external means.

panic was not used, because it would potentially not exit the program if it were recovered from, and in this case we want to exit the program.

Ticket: https://automox.atlassian.net/browse/AXAGENT-3184