### PR TITLE
[BUGS-1698] Deadlock on Reconnecting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ _testmain.go
 
 *.orig
 examples/benchmark/benchmark
+
+# AI Configs for upstream
+CLAUDE.md

--- a/client.go
+++ b/client.go
@@ -1011,7 +1011,7 @@ func (c *Client) startReconnecting() error {
 	go c.reader(t, disconnectCh)
 
 	slog.Debug("centrifuge client is attempting to connect to Centrifugo server")
-	err = c.sendConnect(func(res *protocol.ConnectResult, err error) {
+	if err := c.sendConnect(func(res *protocol.ConnectResult, err error) {
 		c.mu.Lock()
 		if c.state != StateConnecting {
 			c.mu.Unlock()
@@ -1170,8 +1170,7 @@ func (c *Client) startReconnecting() error {
 			go c.waitServerPing(disconnectCh, res.Ping)
 		}
 		c.resubscribe()
-	})
-	if err != nil {
+	}); err != nil {
 		slog.Debug("centrifuge client is failed to connect to Centrifugo server", "reason", err)
 		_ = t.Close()
 		c.reconnectAttempts++

--- a/client.go
+++ b/client.go
@@ -1275,7 +1275,7 @@ func (c *Client) sendRefresh() {
 	}
 	cmd.Refresh = params
 
-	err = c.sendAsync(cmd, func(r *protocol.Reply, err error) {
+	if err := c.sendAsync(cmd, func(r *protocol.Reply, err error) {
 		if err != nil {
 			c.handleError(RefreshError{err})
 			c.mu.Lock()
@@ -1308,11 +1308,9 @@ func (c *Client) sendRefresh() {
 			}
 			c.mu.Unlock()
 		}
-	})
-	if err != nil {
+	}); err != nil {
 		slog.Debug("centrifuge client failed to send refresh error to Centrifugo server", "reason", err)
 	}
-
 }
 
 // Lock must be held outside.

--- a/client.go
+++ b/client.go
@@ -953,8 +953,8 @@ func (c *Client) startReconnecting() error {
 		}
 		c.reconnectAttempts++
 		reconnectDelay := c.getReconnectDelay()
-		c.reconnectTimer = c.reconnectAfter(reconnectDelay)
 		c.mu.Unlock()
+		c.reconnectTimer = c.reconnectAfter(reconnectDelay)
 		return err
 	}
 
@@ -1175,10 +1175,12 @@ func (c *Client) startReconnecting() error {
 		_ = t.Close()
 		c.reconnectAttempts++
 		reconnectDelay := c.getReconnectDelay()
+		c.mu.Unlock()
 		c.reconnectTimer = c.reconnectAfter(reconnectDelay)
 		c.handleError(ConnectError{err})
+	} else {
+		c.mu.Unlock()
 	}
-	c.mu.Unlock()
 	return err
 }
 


### PR DESCRIPTION
This is based on build 0.10.5-beta which is current agent build.

Attempts to fix issue where Deadlock can occur during client reconnections if rapidly fires between startReconnecting() and reconnectAfter().

⏺ Deadlock sequence is:

  1. Line 1174: "centrifuge client is failed to connect to Centrifugo server" - This happens in startReconnecting() around line 268
  2. Line 910: "centrifuge client will attempt to reconnect after a delay" - This is from the timer callback in reconnectAfter()
  3. Line 921: "centrifuge is start to attempt a reconnect" - This is from startReconnecting() being called again

  The deadlock occurs because:

  1. First call to startReconnecting() (line 920-932):
    - Acquires c.mu.Lock() at line 922
    - Fails to connect at line 268: slog.Debug("centrifuge client is failed to connect to Centrifugo server", "reason", err)
    - Still holding the lock, schedules a new timer at line 272: c.reconnectTimer = c.reconnectAfter(reconnectDelay)
    - Releases lock at line 275: c.mu.Unlock()
  2. Timer fires quickly (if delay is very short):
    - Timer callback (line 909-917) executes and calls c.startReconnecting()
    - Logs "centrifuge client will attempt to reconnect after a delay" (line 910)
  3. Second call to startReconnecting():
    - Tries to acquire c.mu.Lock() at line 922
    - Logs "centrifuge is start to attempt a reconnect" (line 921)
    - Blocks here because the first thread might still be holding the lock

  The issue is in the startReconnecting() function around lines 268-275. The code schedules a new reconnect timer while still holding the mutex:

The fix:
  1. Releases the mutex before scheduling the timer: c.mu.Unlock() is called before c.reconnectAfter(reconnectDelay)
  2. Prevents the timer callback from deadlocking: Now when the timer fires and calls c.startReconnecting(), the mutex is already released
  3. Handles both error and success paths: Added an else clause to ensure the mutex is always unlocked

  This prevents the deadlock because the timer callback (which tries to acquire c.mu.Lock() at line 922) can no longer conflict with the thread that schedules the timer.